### PR TITLE
Display correct number of critical updates in apt plugin output

### DIFF
--- a/aptng/agents/plugins/apt
+++ b/aptng/agents/plugins/apt
@@ -2,24 +2,41 @@
 
 if [[ -e /etc/debian_version && `which apt-get` ]] &>/dev/null ; then
     echo "<<<apt>>>"
-    REBOOT_REQUIRED="no"
-    DEBIAN_VERSION=$(cat /etc/debian_version | cut -d '.' -f1)
-    DEB6_RE='^\S+ \S+ \S+ \(Debian ([^\)]+)\).*$'
-    KERNEL_PACKAGE=`dpkg-query -W -f='${Version} ${Status;20} ${Maintainer} ${Provides}\n' |grep 'install ok installed Debian Kernel Team'|grep linux-image| awk '{ print $1 }'`
-    KERNEL=`cat /proc/version`
-    if [[ $DEBIAN_VERSION == '6' ]]; then
-        if [[ $KERNEL =~ $DEB6_RE ]]; then
-            KERNEL_VERSION="${BASH_REMATCH[1]}"
-        fi
-    elif [[ $DEBIAN_VERSION == '7' ]]; then
-            KERNEL_VERSION=$(echo ${KERNEL##* })
+    APT_FILE=$MK_CONFDIR/apt.cache
+    if [ ! -d $MK_CONFDIR ]; then
+        mkdir -p $MK_CONFDIR
     fi
-    for k in $KERNEL_PACKAGE
-    do
-        dpkg --compare-versions $k gt $KERNEL_VERSION && REBOOT_REQUIRED="yes"
-    done
 
-    echo $REBOOT_REQUIRED
-    cat /etc/debian_version
-    waitmax 25 /usr/bin/apt-get -o Debug::NoLocking=yes -s dist-upgrade -y | awk '/^Inst/ { print $2 " " $5}' || echo "timeout_apt_get Debian-Security:X.X/DUMMY)"
+    # Do not use cache file after 4 hours
+    APT_MAXAGE=14400
+
+    # Check if file exists and is recent enough
+    if [ -s $APT_FILE ]
+    then
+        NOW=$(date +%s)
+        MTIME=$(stat -c %Y $APT_FILE)
+        if [ $((NOW - MTIME)) -le $APT_MAXAGE ] ; then
+            USE_APT_FILE=1
+        fi
+    fi
+
+    if [ -z "$USE_APT_FILE" ]
+    then
+        REBOOT_REQUIRED="no"
+        DEBIAN_VERSION=$(cat /etc/debian_version | cut -d '.' -f1)
+        KERNEL_PACKAGE=`dpkg-query -W -f='${Version} ${Status;20} ${Maintainer} ${Provides}\n' |grep 'install ok installed Debian Kernel Team'|grep linux-image|awk '{ print $1 }'`
+        KERNEL=`cat /proc/version`
+        KERNEL_VERSION=$(echo ${KERNEL##* })
+        for k in $KERNEL_PACKAGE
+        do
+            dpkg --compare-versions $k gt $KERNEL_VERSION && REBOOT_REQUIRED="yes"
+        done
+        [ -f /var/run/reboot-required ] && REBOOT_REQUIRED="yes"
+
+        echo $REBOOT_REQUIRED >$APT_FILE
+        cat /etc/debian_version >>$APT_FILE
+        waitmax 25 /usr/bin/apt-get -o Debug::NoLocking=yes -s dist-upgrade -y | awk '/^Inst/ { print $2 " " $5}' >>$APT_FILE
+    fi
+
+    cat $APT_FILE
 fi

--- a/aptng/agents/plugins/apt
+++ b/aptng/agents/plugins/apt
@@ -2,6 +2,7 @@
 
 if [[ -e /etc/debian_version && `which apt-get` ]] &>/dev/null ; then
     echo "<<<apt>>>"
+    REBOOT_REQUIRED="no"
     DEBIAN_VERSION=$(cat /etc/debian_version | cut -d '.' -f1)
     DEB6_RE='^\S+ \S+ \S+ \(Debian ([^\)]+)\).*$'
     KERNEL_PACKAGE=`dpkg-query -W -f='${Version} ${Status;20} ${Maintainer} ${Provides}\n' |grep 'install ok installed Debian Kernel Team'|grep linux-image| awk '{ print $1 }'`
@@ -13,7 +14,12 @@ if [[ -e /etc/debian_version && `which apt-get` ]] &>/dev/null ; then
     elif [[ $DEBIAN_VERSION == '7' ]]; then
             KERNEL_VERSION=$(echo ${KERNEL##* })
     fi
-    if [[ $KERNEL_PACKAGE == $KERNEL_VERSION ]]; then echo "no"; else echo "yes"; fi
+    for k in $KERNEL_PACKAGE
+    do
+        dpkg --compare-versions $k gt $KERNEL_VERSION && REBOOT_REQUIRED="yes"
+    done
+
+    echo $REBOOT_REQUIRED
     cat /etc/debian_version
     waitmax 25 /usr/bin/apt-get -o Debug::NoLocking=yes -s dist-upgrade -y | awk '/^Inst/ { print $2 " " $5}' || echo "timeout_apt_get Debian-Security:X.X/DUMMY)"
 fi

--- a/aptng/checks/apt
+++ b/aptng/checks/apt
@@ -59,19 +59,22 @@ def check_apt(_no_item, _no_params, info):
             updates += 1
             source = package[1].split(' ')[0].split(':')[0]
             if source in apt_repository_severity:
-                level  = max(level, apt_repository_severity[source])
+                severity = apt_repository_severity[source]
             else:
-                level  = max(level, apt_repository_severity['__default__'])
-            
-            if not source in apt_upgrades:
-                apt_upgrades[source] = []
+                severity = apt_repository_severity['__default__']
 
-    for source in apt_upgrades:
-            if level == 1:
-                msg = "%s updates (!)" % updates 
-            elif level >= 2:
-                msg = "%s critical updates (!!)" % updates 
-            
+            if severity >= 2:
+                crit_updates += 1
+
+            level = max(level, severity)
+
+        if (updates > 0) and (crit_updates == updates):
+            msg = "%i critical updates available" % crit_updates
+        elif (updates > 0) and (crit_updates > 0):
+            msg = "%i updates available (%i critical)" % (updates, crit_updates)
+        else:
+            msg = "%i updates available" % updates
+
     if (reboot_req == "yes") and (level == 0):
         level = 1 
         msg = "reboot required (!)"


### PR DESCRIPTION
This commit improves the apt check_mk plugin output by displaying the true number of critical and normal updates in the status message.